### PR TITLE
Add flexible Jalali date parser with support for common date/time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,142 @@
 # Jalali Date Library
+A lightweight Ruby library for converting, formatting, and parsing Jalali (جلالی/Persian/Shamsi) dates.
+
+Jalalidate provides simple APIs for:
+
+* Gregorian → Jalali conversion
+* Jalali → Gregorian conversion
+* Jalali date formatting
+* Parsing Persian date strings
+* Working with Persian numerals and month names
 
 ## Install
+Add this line to your application's Gemfile:
+
+```ruby
+ gem 'jalalidate' 
+```
+
+And then execute:
+
+    $ bundle install
+
+Or install it manually:
 
     $ gem install jalalidate
 
-## Tests
-Simply run `rspec` command in the source directory:
+## Usage
+Date conversion and class methods:
+```ruby
+require 'jalalidate'
 
-    $ rspec
+# Create a jalali date object:
+j_date = JalaliDate.new(1402,02,25)
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 25 >
+
+j_date = JalaliDate.new(Date.today)
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 25 >
+
+# Initialize with hour, minute and second
+j_date = JalaliDate.new(Time.now)
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 25, :hour => 6, :minute => 01, :second => 30 >
+
+# Convert to gregorian date
+g_date = j_date.to_gregorian
+g_date = j_date.to_g
+#=> Mon, 15 May 2023
+
+
+# Get yesterday, today, or tomorrow in jalali
+j_today = JalaliDate.yesterday
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 24 >
+j_today = JalaliDate.today
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 25 >
+j_tomorrow = JalaliDate.tomorrow
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 26 >
+ 
+# Get year, month, and day
+year = j_date.year       #=> 1402
+month = j_date.month     #=> 02
+day = j_date.day         #=> 25
+
+# Get gregorian year, month, and day
+g_year = j_date.g_year   #=> 2023
+g_month = j_date.g_month #=> 5
+g_day = j_date.g_day     #=> 15
+
+# Get day of the year
+dy = j_date.yday #=> 51
+
+# Get the next day
+tomorrow = j_date.next
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 26 >
+
+# Add and substract days
+j_date + 6.days
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 31 >
+j_date + 1.month
+#=> <JalaliDate, :year => 1402, :month => 3, :day => 25 >
+j_date + 2.years + 5.month + 12.days
+#=> <JalaliDate, :year => 1404, :month => 8, :day => 5 >
+
+# Shift the date with number of month
+j_date >> 5
+#=> <JalaliDate, :year => 1402, :month => 7, :day => 25 >
+j_date << 5
+#=> <JalaliDate, :year => 1401, :month => 9, :day => 25 >
+
+# Compare two dates
+j_date < j_date.next       #=> true
+j_date > j_date.next       #=> false
+j_date > j_date.previous   #=> true
+j_date <=> j_date.next     #=> -1
+j_date <=> j_date          #=> 0
+j_date <=> j_date.previous #=> 1
+
+# Cycle through dates in different ways, namely, step, upto and downto
+# every 2 days, including j_date, for the next 10 days
+j_date.step( j_date + 10 , 2)
+
+# every day, including j_date and the next 5 days
+j_date.upto(j_date + 5)
+
+# every day, including j_date and the previous 5 days
+j_date.downto(j_date - 5)
+
+
+# Get day object as array or hash
+j_date.to_a     #=> [1405, 2, 25]
+j_date.to_hash  #=> {year: 1405, month: 2, day: 25}
+
+
+# Check for leap year
+JalaliDate.leap? 1402
+#=> false
+
+# Check for validity of a jalali date
+JalaliDate.valid?(1402,02,25)
+#=> true
+
+JalaliDate.valid?(1402,12,30)
+#=> false
+```
+
+### Date formatting:
+
+```ruby
+# Initialize with hour, minute and second
+j_date = JalaliDate.new(Time.now)
+#=> <JalaliDate, :year => 1402, :month => 2, :day => 25, :hour => 6, :minute => 01, :second => 30 >
+
+j_date.strftime("%a %A %b %B %d %e %j %m %w %y %Y %% %x")
+#=> "۲ش دوشنبه اردیبهشت Ordibehesht 25 25 56 2 1 02 1402 % 02/2/25"
+
+j_date.strftime("%X")
+#=> "06:01:30"
+
+j_date.strftime("%H:%M - %Y/%n/%d")
+#=> "06:01 - 1402/02/25"
+```
 
 ## Format meanings:
 
@@ -33,6 +162,43 @@ Simply run `rspec` command in the source directory:
 - `[%X]` Preferred representation for the time alone, no date
 - `[%Z]` Time zone name
 - `[%%]` teral %'' character
+
+## Parsing Jalali Dates
+
+The parser supports multiple common Persian date formats.
+
+### Numeric Formats
+```ruby
+JalaliDate.parse('1402/02/25')
+JalaliDate.parse('1402-02-25')
+JalaliDate.parse('1402.02.25')
+```
+### Persian Month Names
+```ruby 
+JalaliDate.parse('25 اردیبهشت 1402')
+JalaliDate.parse('اردیبهشت 25 1402')
+```
+
+### DateTime Parsing
+```ruby 
+JalaliDate.parse('1402/02/25 06:01')
+JalaliDate.parse('1402/02/25 06:01:30')
+JalaliDate.parse('25 اردیبهشت ۱۴۰۲ ساعت ۰۶:۰۱')
+```
+
+### Persian Digits
+
+The parser automatically normalizes Persian and Arabic numerals:
+
+```ruby
+JalaliDate.parse('۱۴۰۲/۰۲/۲۵')
+JalaliDate.parse('١٤٠۲/٠٢/٢٥')
+```
+
+## Tests
+Simply run `rspec` command in the source directory:
+
+    $ bundle exec rspec
 
 ## History
 

--- a/lib/jalalidate.rb
+++ b/lib/jalalidate.rb
@@ -5,6 +5,7 @@ if RUBY_VERSION < '1.9'
   $KCODE = 'u'
 end
 require "date"
+require "jalalidate_parser"
 
 class JalaliDate
 
@@ -72,6 +73,12 @@ class JalaliDate
     # Return a JalaliDate object representing tomorrow's date in calendar
     def tomorrow
       JalaliDate.new(Date.today + 1)
+    end
+
+    # Return JalaliDate from a provided string
+    def parse(s)
+      date = JalaliDateParser.parse(s)
+      date[:jalali]
     end
 
     # Accpets a four digit number as the jalaliyear and returns true if that particular year

--- a/lib/jalalidate_parser.rb
+++ b/lib/jalalidate_parser.rb
@@ -119,7 +119,7 @@ module JalaliDateParser
 
       validate!(year, month, day, hour, min, sec)
 
-      jdate = JalaliDate.new(year, month, day)
+      jdate = JalaliDate.new(year, month, day, hour, min, sec)
       gdate = jdate.to_gregorian.to_datetime
 
       return {

--- a/lib/jalalidate_parser.rb
+++ b/lib/jalalidate_parser.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+# Usage:
+#   JalaliDateParser.parse("1402/02/25")
+#   JalaliDateParser.parse("۱۴۰۲-۰۲-۲۵ ۰۶:۰۱")
+#   JalaliDateParser.parse("25 اردیبهشت 1402")
+#   JalaliDateParser.parse("25 اردیبهشت 1402 ساعت 6:01:30")
+#   JalaliDateParser.parse("1402.2.25")
+#   JalaliDateParser.parse("1402/02/25T06:01:30")
+#
+# Returns:
+#   {
+#     jalali: #<JalaliDate ...>,
+#     gregorian: #<DateTime ...>,
+#     components: {
+#       year: 1402,
+#       month: 2,
+#       day: 25,
+#       hour: 06,
+#       min: 01,
+#       sec: 30
+#     }
+#   }
+
+require "date"
+require "jalalidate"
+
+module JalaliDateParser
+  PERSIAN_DIGITS = "۰۱۲۳۴۵۶۷۸۹"
+  ENGLISH_DIGITS = "0123456789"
+  ARABIC_DIGITS = "٠١٢٣٤٥٦٧٨٩"
+
+  MONTHS = {
+    "فروردین" => 1,
+    "اردیبهشت" => 2,
+    "خرداد" => 3,
+    "تیر" => 4,
+    "مرداد" => 5,
+    "شهریور" => 6,
+    "مهر" => 7,
+    "آبان" => 8,
+    "آذر" => 9,
+    "دی" => 10,
+    "بهمن" => 11,
+    "اسفند" => 12
+  }.freeze
+
+  COMMON_PATTERNS = [
+    # 1403/01/15
+    # 1403-01-15
+    # 1403.01.15
+    {
+      regex: /
+        (?<year>\d{4})
+        [\/\-.]
+        (?<month>\d{1,2})
+        [\/\-.]
+        (?<day>\d{1,2})
+        (?:[T\s]+(?<time>\d{1,2}:\d{1,2}(?::\d{1,2})?))?
+      /x
+    },
+
+    # 15/01/1403
+    # 15-01-1403
+    {
+      regex: /
+        (?<day>\d{1,2})
+        [\/\-.]
+        (?<month>\d{1,2})
+        [\/\-.]
+        (?<year>\d{4})
+        (?:[T\s]+(?<time>\d{1,2}:\d{1,2}(?::\d{1,2})?))?
+      /x
+    },
+
+    # 15 فروردین 1403
+    # فروردین 15 1403
+    {
+      regex: /
+        (?:
+          (?<day>\d{1,2})\s+
+          (?<month_name>[[:word:]\p{Arabic}]+)\s+
+          (?<year>\d{4})
+          |
+          (?<month_name2>[[:word:]\p{Arabic}]+)\s+
+          (?<day2>\d{1,2})\s+
+          (?<year2>\d{4})
+        )
+        (?:.*?(?<time>\d{1,2}:\d{1,2}(?::\d{1,2})?))?
+      /x
+    }
+  ].freeze
+
+  class ParseError < StandardError; end
+
+  module_function
+
+  def parse(input)
+    raise ParseError, "Empty input" if input.nil? || input.strip.empty?
+
+    str = normalize(input)
+
+    COMMON_PATTERNS.each do |pattern|
+      match = str.match(pattern[:regex])
+      next unless match
+
+      year  = (match[:year] || match[:year2]).to_i
+      day   = (match[:day] || match[:day2]).to_i
+
+      month =
+        if match.names.include?("month")
+          match[:month].to_i
+        else
+          MONTHS[match[:month_name] || match[:month_name2]]
+        end
+
+      hour, min, sec = extract_time(match[:time])
+
+      validate!(year, month, day, hour, min, sec)
+
+      jdate = JalaliDate.new(year, month, day)
+      gdate = jdate.to_gregorian.to_datetime
+
+      return {
+        jalali: jdate,
+        gregorian: gdate,
+        components: {
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          min: min,
+          sec: sec
+        }
+      }
+    end
+
+    raise ParseError, "Unsupported Jalali date format: #{input}"
+  end
+
+  def normalize(str)
+    s = str.dup
+
+    # Persian/Arabic digits → English
+    s.tr!(PERSIAN_DIGITS, ENGLISH_DIGITS)
+    s.tr!(ARABIC_DIGITS, ENGLISH_DIGITS)
+
+    # Normalize Arabic chars
+    s.gsub!("ي", "ی")
+    s.gsub!("ك", "ک")
+
+    # Remove extra words
+    s.gsub!(/ساعت|در|،/, " ")
+
+    # Normalize whitespace
+    s.gsub!(/\s+/, " ")
+
+    s.strip
+  end
+
+  def extract_time(time_str)
+    return [0, 0, 0] unless time_str
+
+    parts = time_str.split(":").map(&:to_i)
+
+    [
+      parts[0] || 0,
+      parts[1] || 0,
+      parts[2] || 0
+    ]
+  end
+
+  def validate!(year, month, day, hour, min, sec)
+    raise ParseError, "Invalid year" unless year > 0
+    raise ParseError, "Invalid month" unless month.between?(1, 12)
+    raise ParseError, "Invalid day" unless day.between?(1, 31)
+    raise ParseError, "Invalid hour" unless hour.between?(0, 23)
+    raise ParseError, "Invalid minute" unless min.between?(0, 59)
+    raise ParseError, "Invalid second" unless sec.between?(0, 59)
+  end
+end

--- a/spec/jalalidate_spec.rb
+++ b/spec/jalalidate_spec.rb
@@ -146,4 +146,13 @@ describe JalaliDate do
     JalaliDate.new(time).strftime("%Z").should == time.zone
   end
 
+  it "should be able to parse different formats of jalali dates" do
+    JalaliDate.parse("1402/02/25").should == JalaliDate.new(1402,2,25)
+    JalaliDate.parse("۱۴۰۲-۰۲-۲۵ ۰۶:۰۱").should == JalaliDate.new(1402,2,25)
+    JalaliDate.parse("25 اردیبهشت 1402").should == JalaliDate.new(1402,2,25)
+    JalaliDate.parse("25 اردیبهشت 1402 ساعت 6:01:30").should == JalaliDate.new(1402,2,25)
+    JalaliDate.parse("1402.2.25").should == JalaliDate.new(1402,2,25)
+    JalaliDate.parse("1402/02/25T06:01:30").should == JalaliDate.new(1402,2,25)
+  end
+
 end


### PR DESCRIPTION
### Summary

This PR adds a robust Jalali date parser capable of handling many commonly used Persian and Jalali date formats, including:

- **Numeric formats:**

  - 1402/02/25
  - 1402-02-25
  - 1402.02.25
  - 25/02/1402

- **Persian month name formats:**

  - 25 اردیبهشت 1402
  - اردیبهشت 25 1402

- **DateTime parsing:**

  - 1402/02/25 06:01
  - 1402/02/25T06:01:30
  - ۲۵ اردیبهشت ۱۴۰۲ ساعت ۶:۰۱

- **Persian and Arabic digit normalization:**

  - ۱۴۰۲/۰۲/۲۵
  - ١٤٠۲/٠۲/۲٥

### **Features**

- Supports multiple separators (/, -, .)
- Supports optional time parsing
- Handles Persian and Arabic numerals
- Normalizes Arabic/Persian character variants (ي → ی, ك → ک)
- Converts parsed Jalali dates to Gregorian DateTime
- Includes input validation and meaningful parsing errors

### **Motivation**

Many Ruby applications working with Persian users receive Jalali dates in inconsistent formats depending on user input methods, keyboards, locale settings, or frontend implementations.

This parser aims to provide a single reliable entry point for parsing user-provided Jalali date strings into structured and normalized date objects.

### **Example**
```ruby 
result = JalaliDate.parse("25 اردیبهشت 1402")
=> #<JalaliDate, :year => 1402, :month => 2, :day => 25 >
```

### **Notes**

The implementation was designed to be extensible so additional Jalali formats can be added easily in the future.

Feedback and suggestions are welcome.